### PR TITLE
Propagate exceptions raised within block

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Aw.fork! { arr << 'FUU' } # => ["foo", "FUU"]
 arr # => ["foo"]
 ```
 
+Exceptions raised within the block are propagated:
+
+```ruby
+Aw.fork! { nil + 1 } # => NoMethodError (undefined method `+' for nil:NilClass)
+```
+
 ## Security
 
 As a basic form of security __Aw__ provides a set of SHA512 checksums for

--- a/lib/aw/fork.rb
+++ b/lib/aw/fork.rb
@@ -35,7 +35,9 @@ module Aw
       Process.wait(pid)
 
       # rubocop:disable MarshalLoad
-      Marshal.load(result)
+      Marshal.load(result).tap do |r|
+        raise r if r.is_a?(Exception)
+      end
       # rubocop:enable MarshalLoad
     end
 
@@ -44,7 +46,11 @@ module Aw
     def fork_and_return_pid
       fork do
         read.close
-        result = yield
+        begin
+          result = yield
+        rescue
+          result = $!
+        end
         Marshal.dump(result, write)
         exit!(0)
       end

--- a/test/test_aw.rb
+++ b/test/test_aw.rb
@@ -11,3 +11,10 @@ raise unless 'bar'.eql?(Aw.fork! { 'bar' })
 
 # It is expected to be nil
 raise unless (Aw.fork! {}).nil?
+
+# It is expected to raise
+begin
+  Aw.fork! { raise "an exception" }
+rescue
+  raise unless $!.message == 'an exception'
+end


### PR DESCRIPTION
Ensures exceptions within passed block are propagated instead of generating an ArgumentError during marshalling.

Before:

```ruby
Aw.fork! { raise 'an exception' }
=> marshal data too short (ArgumentError)
```

After:

```ruby
Aw.fork! { raise 'an exception' }
=> an exception (RuntimeError)
```
